### PR TITLE
Add syntax highlighting to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,20 +25,26 @@ returns a new relation by "pivoting" around a named association.
 
 Say we have a `Post` model and each `Post` belongs to an author:
 
-    class Post < ActiveRecord::Base
-      belongs_to :author
-    end
-  
+```ruby
+class Post < ActiveRecord::Base
+  belongs_to :author
+end
+```
+
 To turn a relation of posts into a relation of its authors:
 
-    posts = Post.where(archived: false)
-    authors = posts.traverse_association(:author)
-    
+```ruby
+posts = Post.where(archived: false)
+authors = posts.traverse_association(:author)
+```
+
 You can traverse multiple associations in a single call.
 E.g. to turn a relation of posts into a relation of all posts of their authors:
 
-    posts = Post.where(archived: false)
-    posts_by_same_authors = posts.traverse_association(:author, :posts)
+```ruby
+posts = Post.where(archived: false)
+posts_by_same_authors = posts.traverse_association(:author, :posts)
+```
 
 *Implementation note:* The traversal is achieved internally by collecting all foreign keys in the current relation
 and return a new relation with an `IN(...)` query (which is very efficient even for many thousand keys).
@@ -56,8 +62,10 @@ its ID.
 Edge Rider has a better way. Your relations gain a method `#collect_ids` that will
 fetch all IDs in a single query without instantiating a single ActiveRecord object:
 
-    posts = Post.where(archived: false)
-    post_ids = posts.collect_ids
+```ruby
+posts = Post.where(archived: false)
+post_ids = posts.collect_ids
+```
 
 *Implementation note:* `#collect_ids` delegates to [`#pluck`](https://apidock.com/rails/ActiveRecord/Calculations/pluck),
 which can be used for the same purpose.
@@ -68,33 +76,39 @@ which can be used for the same purpose.
 When writing a method that filters by record IDs, you can make it more useful by accepting
 any kind of argument that can be turned into a list of IDs:
 
-    Post.by_author(1)
-    Post.by_author([1, 2, 3])
-    Post.by_author(Author.find(1))
-    Post.by_author([Author.find(1), Author.find(2)])
-    Post.by_author(Author.active)
+```ruby
+Post.by_author(1)
+Post.by_author([1, 2, 3])
+Post.by_author(Author.find(1))
+Post.by_author([Author.find(1), Author.find(2)])
+Post.by_author(Author.active)
+```
 
 For this use case Edge Rider defines `#collect_ids` on many different types:
 
-    Post.where(id: [1, 2]).collect_ids    # => [1, 2]
-    [Post.find(1), Post.find(2)].collect_ids # => [1, 2]
-    Post.find(1).collect_ids                 # => [1]
-    [1, 2, 3].collect_ids                    # => [1, 2, 3]
-    1.collect_ids                            # => [1]
+```ruby
+Post.where(id: [1, 2]).collect_ids    # => [1, 2]
+[Post.find(1), Post.find(2)].collect_ids # => [1, 2]
+Post.find(1).collect_ids                 # => [1]
+[1, 2, 3].collect_ids                    # => [1, 2, 3]
+1.collect_ids                            # => [1]
+```
 
 You can now write `Post.by_author` from the example above without a single `if` or `case`:
 
-    class Post < ActiveRecord::Base
-    
-      belongs_to :author
+```ruby
+class Post < ActiveRecord::Base
 
-      def self.for_author(author_or_authors)
-        where(author_id: author_or_authors.collect_ids)
-      end
+  belongs_to :author
 
-    end
-    
-    
+  def self.for_author(author_or_authors)
+    where(author_id: author_or_authors.collect_ids)
+  end
+
+end
+```
+
+
 ### Efficiently collect all values in a relation's column
 
 You often want to ask a relation for an array of all values ofin a given column.
@@ -106,8 +120,10 @@ its column value.
 Edge Rider has a better way. Your relations gain a method `#collect_column` that will
 fetch all column values in a single query without instantiating a single ActiveRecord object:
 
-    posts = Post.where(archived: false)
-    subjects = posts.collect_column(:subject)
+```ruby
+posts = Post.where(archived: false)
+subjects = posts.collect_column(:subject)
+```
 
 *Implementation note:* `#collect_column` delegates to [`#pluck`](https://apidock.com/rails/ActiveRecord/Calculations/pluck),
 which can be used for the same effect.
@@ -116,8 +132,10 @@ which can be used for the same effect.
 
 If you only care about *unique* values, use the `distinct: true` option:
 
-    posts = Post.where(archived: false)
-    distinct_subjects = posts.collect_column(:subject, distinct: true)
+```ruby
+posts = Post.where(archived: false)
+distinct_subjects = posts.collect_column(:subject, distinct: true)
+```
 
 With this options duplicates are discarded by the database before making their way into Ruby.
 
@@ -136,15 +154,21 @@ mashes together strings that mostly happen to look like a MySQL query in the end
 
 Edge Rider gives your relations a new method `#to_id_query`:
 
-    Site.joins(user).where(:users: { name: 'Bruce' }).to_id_query
+```ruby
+Site.joins(user).where(:users: { name: 'Bruce' }).to_id_query
+```
 
 `#to_id_query` will immediately run an SQL query where it collects all the IDs that match your relation:
 
-    SELECT sites.id FROM sites INNER JOIN users WHERE sites.user_id = sites.id AND users.name = 'Bruce'
+```sql
+SELECT sites.id FROM sites INNER JOIN users WHERE sites.user_id = sites.id AND users.name = 'Bruce'
+```
 
 It now uses these IDs to return a new relation that has **no joins** and a single condition on the `id` column:
 
-    SELECT * FROM sites WHERE sites.user_id IN (3, 17, 103)
+```sql
+SELECT * FROM sites WHERE sites.user_id IN (3, 17, 103)
+```
 
 
 ### Preload associations for loaded ActiveRecords
@@ -153,10 +177,12 @@ Sometimes you want to fetch associations for records that you already instantiat
 
 Edge Rider gives your model classes and instances a method `preload_associations`. The method can be used to preload associations for loaded objects like this:
 
-    @user = User.find(params[:id])
-    User.preload_associations [@user], { threads: { posts: :author }, messages: :sender }
-    # or
-    user.preload_associations { threads: { posts: :author }, messages: :sender }
+```ruby
+@user = User.find(params[:id])
+User.preload_associations [@user], { threads: { posts: :author }, messages: :sender }
+# or
+user.preload_associations { threads: { posts: :author }, messages: :sender }
+```
 
 *Implementation note*: Rails 3.0 already has a method [`.preload_associations`](https://apidock.com/rails/ActiveRecord/AssociationPreload/ClassMethods/preload_associations)
 which Edge Rider merely makes public. Edge Rider ports this method forward to Rails 3.1+.
@@ -168,8 +194,10 @@ which Edge Rider merely makes public. Edge Rider ports this method forward to Ra
 Edge Rider gives your relations a method `#origin_class` that returns the class the relation is based on.
 This is useful e.g. to perform unscoped record look-up.
 
-    Post.recent.origin_class
-    # => Post
+```ruby
+Post.recent.origin_class
+# => Post
+```
 
 Note that `#origin_class` it roughly equivalent to the blockless form of [`unscoped`](https://apidock.com/rails/ActiveRecord/Scoping/Default/ClassMethods/unscoped) from Rails 3.2+,
 but it works consistently across all Rails versions.
@@ -182,8 +210,10 @@ Edge Rider ports `Model.scoped` forward to Rails 4+ (taken from
 enables you to consistently turn models into scopes or narrow down scopes
 across all versions of Rails.
 
-    User.scoped # just calls User.all in Rails 4
-    User.active.scoped(conditions: { admin: true })
+```ruby
+User.scoped # just calls User.all in Rails 4
+User.active.scoped(conditions: { admin: true })
+```
 
 *Implementation note*: Rails 3 already have a method
 [`.scoped`](https://apidock.com/rails/ActiveRecord/Scoping/Named/ClassMethods/scoped) which Edge Rider does not touch. Rails 4 has removed this method and


### PR DESCRIPTION
This change will add [syntax highlighting](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#syntax-highlighting) to the README.md if rendered at GitHub.

## Why?

It's easier to read code if highlighted.

## Screenshots

### Before

SQL:

![markdown-sql-before](https://user-images.githubusercontent.com/385500/75906287-c12e9a80-5e46-11ea-92e3-d2c0528eeb55.png)

Ruby:

![markdown-ruby-before](https://user-images.githubusercontent.com/385500/75906290-c2f85e00-5e46-11ea-8121-7e66d6497281.png)

### After

SQL:

![markdown-sql-after](https://user-images.githubusercontent.com/385500/75906305-c8ee3f00-5e46-11ea-9211-75eba47faa9e.png)

Ruby:

![markdown-ruby-after](https://user-images.githubusercontent.com/385500/75906307-c986d580-5e46-11ea-81b2-2a19115067f1.png)

