### PR TITLE
Fix test error for mysql installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,8 @@ jobs:
         ruby-version: "${{ matrix.ruby }}"
     - name: Setup database
       run: |
-        sudo apt-get install -y mysql-client libmariadbclient-dev
+        sudo apt-get update
+        sudo apt-get install -y mariadb-client libmariadbclient-dev
         mysql -e 'create database IF NOT EXISTS test;' -u root --password=password -P 3306 -h 127.0.0.1
     - name: Bundle
       run: |


### PR DESCRIPTION
```
The following packages have unmet dependencies:
 mysql-client : Depends: mysql-client-8.0 but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
Error: Process completed with exit code 100.
```