### PR TITLE
Allow "string IDs" for collect_ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Compatible changes
 
+- `collect_ids` is now capable of parsing "string arrays" like `['1', '2', '3']`. This can be handy when handling params with ID arrays.
 
 ## 2.2.0 - 2023-03-01
 

--- a/lib/edge_rider/collect_ids.rb
+++ b/lib/edge_rider/collect_ids.rb
@@ -8,9 +8,18 @@ module EdgeRider
       def collect_ids
         collect do |obj|
           case obj
-            when Integer then obj
-            when ActiveRecord::Base then obj.id
-            else raise Uncollectable, "Cannot collect an id from #{obj.inspect}"
+          when Integer
+            obj
+          when ActiveRecord::Base
+            obj.id
+          when String
+            if obj.match(/\A\d+\z/)
+              obj.to_i
+            else
+              raise Uncollectable, "Cannot collect an id from #{obj.inspect}"
+            end
+          else
+            raise Uncollectable, "Cannot collect an id from #{obj.inspect}"
           end
         end
       end


### PR DESCRIPTION
This PR extends edge_riders `collect_ids` method for two use cases:
* It now supports arrays of string IDs (e.g. when provided by HTTP parameters)
  *  `["1", "2", "3"].collect_ids # [1, 2, 3]`
* As a side effect, strings containing natural numbers (`"3"`) now implement the `collect_ids` method
  * `"345".collect_ids # [345]`

It allows wider use cases for the `to_id_query` method or common implementations of `these(ids)`

Fixes https://github.com/makandra/edge_rider/issues/18