### PR TITLE
Use Ubuntu 22.04 as a base image for postgres tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Run tests
       run: bundle exec rspec
   test_pg:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgres


### PR DESCRIPTION
The mirror at http://azure.archive.ubuntu.com/ubuntu/pool/main/p/postgresql-12/ no longer contains postgresql-12.12.14 which causes our tests to fail - 12.12.15 however is available.

I guess the mentioned exception will resolve itself over the next release, but we'll upgrade to 22.04 either way in the future.